### PR TITLE
Enable manual workflow triggering

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
+  workflow_dispatch:
 
 jobs:
   build-and-test:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,4 +22,4 @@ jobs:
       run: xcodebuild clean build test -project EssentialFeed/EssentialFeed.xcodeproj -scheme "CI_macOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk macosx -destination "platform=macOS" ONLY_ACTIVE_ARCH=YES
 
     - name: iOS Build and test
-       run: xcodebuild clean build test -project EssentialFeed/EssentialFeed.xcodeproj -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=16.2" ONLY_ACTIVE_ARCH=YES
+      run: xcodebuild clean build test -project EssentialFeed/EssentialFeed.xcodeproj -scheme "CI_iOS" CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 14,OS=16.2" ONLY_ACTIVE_ARCH=YES


### PR DESCRIPTION
Add `workflow_dispatch` to the CI workflow configuration.

This allows the workflow to be manually started from the GitHub Actions UI, which will help you in diagnosing any existing CI issues by allowing for on-demand runs and inspection of logs.